### PR TITLE
Add --experimental-worker flag to npm start script

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "./build/index.js",
   "scripts": {
-    "start": "node --inspect=5858 -r ts-node/register ./src/index.ts",
+    "start": "node --experimental-worker --inspect=5858 -r ts-node/register ./src/index.ts",
     "start:watch": "nodemon",
     "test": "jest --config jestconfig.json",
     "build": "tsc",


### PR DESCRIPTION
`npm start` wouldn't run the first time without it on Node 10.15.2:

`
error: Main errorCannot find module 'worker_threads' {"code":"MODULE_NOT_FOUND","stack":"Error: Cannot find module 'worker_threads'\n    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:581:15)\n    at Function.Module._load (internal/modules/cjs/loader.js:507:25)\n    at Module.require (internal/modules/cjs/loader.js:637:17)\n    at require (internal/modules/cjs/helpers.js:22:18)\n    at Object.<anonymous> 
`